### PR TITLE
Calling powershell in noninteractive way so we could automate the build

### DIFF
--- a/make.cmd
+++ b/make.cmd
@@ -3,6 +3,6 @@
 set PATH=C:\Program Files\mingw-w64\x86_64-6.3.0-win32-seh-rt_v5-rev2\mingw64\bin;%PATH%
 set CPATH=C:\Program Files (x86)\WinFsp\inc\fuse
 
-for /f %%d in ('powershell "Get-Date -UFormat %%y%%j"') do set MyBuildNumber=%%d
+for /f %%d in ('powershell -NoProfile -NonInteractive -ExecutionPolicy Unrestricted "Get-Date -UFormat %%y%%j"') do set MyBuildNumber=%%d
 
 mingw32-make MyBuildNumber=%MyBuildNumber% %*


### PR DESCRIPTION
I would like to run make.cmd on a build server (from the msbuild script) and adding those parameters to the PowerShell call fixes some problems I have.